### PR TITLE
feat(chart): Add hostnetwork value  for the CCM deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,12 @@ helm-release: ## Helm Release
 docs:
 	yq -i '.appVersion = "$(TAG)"' charts/xenorchestra-cloud-controller-manager/Chart.yaml -y
 	helm template -n kube-system xenorchestra-cloud-controller-manager \
+		-f charts/xenorchestra-cloud-controller-manager/values.hostnetwork.yaml \
+		charts/xenorchestra-cloud-controller-manager > docs/deploy/cloud-controller-manager-hostnetwork.yml
+	helm template -n kube-system xenorchestra-cloud-controller-manager \
+		-f charts/xenorchestra-cloud-controller-manager/values.edge.yaml \
+		charts/xenorchestra-cloud-controller-manager > docs/deploy/cloud-controller-manager-edge.yml
+	helm template -n kube-system xenorchestra-cloud-controller-manager \
 		--set-string image.tag=$(TAG) \
 		charts/xenorchestra-cloud-controller-manager > docs/deploy/cloud-controller-manager.yml
 	helm-docs --sort-values-order=file charts/xenorchestra-cloud-controller-manager

--- a/charts/xenorchestra-cloud-controller-manager/README.md
+++ b/charts/xenorchestra-cloud-controller-manager/README.md
@@ -107,3 +107,4 @@ helm upgrade -i --namespace=kube-system -f xo-ccm.yaml \
 | affinity | object | `{}` | Affinity for data pods assignment. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | extraVolumes | list | `[]` | Additional volumes for Pods |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for Pods |
+| useHostNetwork | bool | `false` | Host networking requested for the CCM Pod |

--- a/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       serviceAccountName: {{ include "xenorchestra-cloud-controller-manager.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.useHostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/xenorchestra-cloud-controller-manager/values.edge.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/values.edge.yaml
@@ -2,16 +2,4 @@ image:
   pullPolicy: Always
   tag: edge
 
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-
 logVerbosityLevel: 4
-
-enabledControllers:
-  - cloud-node
-  - cloud-node-lifecycle

--- a/charts/xenorchestra-cloud-controller-manager/values.hostnetwork.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/values.hostnetwork.yaml
@@ -1,0 +1,2 @@
+# --  Host networking requested for the CCM Pod
+useHostNetwork: true

--- a/charts/xenorchestra-cloud-controller-manager/values.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/values.yaml
@@ -145,3 +145,6 @@ extraVolumes: []
 
 # -- Additional volume mounts for Pods
 extraVolumeMounts: []
+
+# --  Host networking requested for the CCM Pod
+useHostNetwork: false

--- a/docs/deploy/cloud-controller-manager-edge.yml
+++ b/docs/deploy/cloud-controller-manager-edge.yml
@@ -1,0 +1,209 @@
+---
+# Source: xenorchestra-cloud-controller-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.2
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v0.0.3"
+    app.kubernetes.io/managed-by: Helm
+  namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.2
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v0.0.3"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+---
+# Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:xenorchestra-cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:xenorchestra-cloud-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:xenorchestra-cloud-controller-manager:extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.2
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v0.0.3"
+    app.kubernetes.io/managed-by: Helm
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+      app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+        app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    spec:
+      enableServiceLinks: false
+      priorityClassName: system-cluster-critical
+      serviceAccountName: xenorchestra-cloud-controller-manager
+      securityContext:
+        fsGroup: 10258
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 10258
+        runAsNonRoot: true
+        runAsUser: 10258
+      initContainers: []
+      containers:
+        - name: xenorchestra-cloud-controller-manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/vatesfr/xenorchestra-cloud-controller-manager:edge"
+          imagePullPolicy: Always
+          args:
+            - --v=4
+            - --cloud-provider=xenorchestra
+            - --cloud-config=/etc/xenorchestra/config.yaml
+            - --controllers=cloud-node,cloud-node-lifecycle
+            - --leader-elect-resource-name=cloud-controller-manager-xenorchestra
+            - --use-service-account-credentials
+            - --secure-port=10258
+            - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
+          ports:
+            - name: metrics
+              containerPort: 10258
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /etc/xenorchestra
+              readOnly: true
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+                    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+                topologyKey: topology.kubernetes.io/zone
+              weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+              app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: xenorchestra-cloud-controller-manager
+            defaultMode: 416

--- a/docs/deploy/cloud-controller-manager-hostnetwork.yml
+++ b/docs/deploy/cloud-controller-manager-hostnetwork.yml
@@ -1,0 +1,211 @@
+---
+# Source: xenorchestra-cloud-controller-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.2
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v0.0.3"
+    app.kubernetes.io/managed-by: Helm
+  namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.2
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v0.0.3"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+---
+# Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:xenorchestra-cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:xenorchestra-cloud-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:xenorchestra-cloud-controller-manager:extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.2
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v0.0.3"
+    app.kubernetes.io/managed-by: Helm
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+      app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+        app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    spec:
+      enableServiceLinks: false
+      priorityClassName: system-cluster-critical
+      serviceAccountName: xenorchestra-cloud-controller-manager
+      securityContext:
+        fsGroup: 10258
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 10258
+        runAsNonRoot: true
+        runAsUser: 10258
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      initContainers: []
+      containers:
+        - name: xenorchestra-cloud-controller-manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/vatesfr/xenorchestra-cloud-controller-manager:v0.0.3"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --cloud-provider=xenorchestra
+            - --cloud-config=/etc/xenorchestra/config.yaml
+            - --controllers=cloud-node,cloud-node-lifecycle
+            - --leader-elect-resource-name=cloud-controller-manager-xenorchestra
+            - --use-service-account-credentials
+            - --secure-port=10258
+            - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
+          ports:
+            - name: metrics
+              containerPort: 10258
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /etc/xenorchestra
+              readOnly: true
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+                    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+                topologyKey: topology.kubernetes.io/zone
+              weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+              app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: xenorchestra-cloud-controller-manager
+            defaultMode: 416


### PR DESCRIPTION
# Pull Request

## What? (description)

This PR enables the deployment to request the use of the host network.


It also adds the generation of 2 deployments: one is for the edge tag (master branch), the others are with or without the host network.

## Why? (reasoning)

The XO CCM may need access to the host network to reach the XO API.

## Acceptance

Please use the following checklist:

- [x] you linted your code (`make lint`)
- [x] you tested your code (`make unit`)
