### PR TITLE
Feat/record event when region zone changed

### DIFF
--- a/pkg/controllers/nodelabelsync/helper_test.go
+++ b/pkg/controllers/nodelabelsync/helper_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2025 Vatesfr.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package nodelabelsync
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vatesfr/xenorchestra-cloud-controller-manager/pkg/xenorchestra"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cloudprovider "k8s.io/cloud-provider"
+)
+
+// Create instance metadata with additional labels
+var instanceMetadataTest = &cloudprovider.InstanceMetadata{
+	AdditionalLabels: map[string]string{
+		xenorchestra.XOLabelNamespace + "/test-label": "test-value",
+	},
+	Zone:         "zone-1",
+	Region:       "region-1",
+	InstanceType: "vm-type-1",
+}
+
+func TestGetNodeLabelUpdate_ReturnsNilForTaintedNode(t *testing.T) {
+	// Create a node with cloud taint
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Spec: v1.NodeSpec{
+			Taints: []v1.Taint{
+				{
+					Key:    "node.cloudprovider.kubernetes.io/uninitialized",
+					Value:  "true",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	// Call the function
+	result := getNodeLabelUpdate(node, instanceMetadataTest)
+
+	// Assert that the function returns nil for tainted nodes
+	assert.Nil(t, result, "Expected nil for tainted node")
+}
+
+func TestGetNodeLabelUpdate_AddsOrUpdatesXONamespaceLabels(t *testing.T) {
+	// Labels to test
+	expectedXOLabel1 := xenorchestra.XOLabelNamespace + "/custom-label"
+	expectedXOLabel2 := xenorchestra.XOLabelNamespace + "/another-label"
+	existingXOLabel1 := xenorchestra.XOLabelNamespace + "/existing-label"
+	existingXOLabel2 := xenorchestra.XOLabelNamespace + "/another-existing-label"
+
+	// Create a node without cloud taint and without existing XO labels
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				existingXOLabel1: "existing-value",
+				existingXOLabel2: "another-existing-value",
+			},
+		},
+		Spec: v1.NodeSpec{
+			Taints: []v1.Taint{}, // No taints
+		},
+	}
+
+	// Create instance metadata with XO namespace labels
+	instanceMetadata := &cloudprovider.InstanceMetadata{
+		AdditionalLabels: map[string]string{
+			expectedXOLabel1: "custom-value",
+			expectedXOLabel2: "another-value",
+			existingXOLabel1: "new-value",
+			existingXOLabel2: "another-existing-value",
+			"non-xo-label":   "should-be-ignored",
+		},
+	}
+
+	// Call the function
+	result := getNodeLabelUpdate(node, instanceMetadata)
+
+	// Assert that XO namespace labels are included in the result and updated
+	assert.Equal(t, "custom-value", result[expectedXOLabel1], "Expected XO label %s to be 'custom-value'", expectedXOLabel1)
+	assert.Equal(t, "another-value", result[expectedXOLabel2], "Expected XO label %s to be 'another-value'", expectedXOLabel2)
+	assert.Equal(t, "new-value", result[existingXOLabel1], "Expected XO label %s to be 'new-value'", existingXOLabel1)
+
+	// Assert that XO labels are not included if not need to update
+	assert.NotContains(t, result, existingXOLabel2, "Expected XO label %s to not be included", existingXOLabel2)
+
+	// Assert that non-XO labels are not included
+	assert.NotContains(t, result, "non-xo-label", "Non-XO label should not be included in the result")
+
+	// Assert that the result contains the expected number of XO labels
+	xoLabelCount := 0
+	for key := range result {
+		if strings.Contains(key, xenorchestra.XOLabelNamespace) {
+			xoLabelCount++
+		}
+	}
+
+	assert.Equal(t, 3, xoLabelCount, "Expected 3 XO namespace labels")
+}
+
+func TestGetNodeLabelUpdate_ZoneChangedAddsOriginalHostAndUpdatesLabels(t *testing.T) {
+	// Node has an existing zone that differs from metadata.Zone
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+			Labels: map[string]string{
+				v1.LabelTopologyZone: "zone-1",
+			},
+		},
+		Spec: v1.NodeSpec{Taints: []v1.Taint{}},
+	}
+
+	meta := &cloudprovider.InstanceMetadata{Zone: "zone-2"}
+
+	result := getNodeLabelUpdate(node, meta)
+
+	assert.Equal(t, "zone-2", result[v1.LabelTopologyZone], "zone label should be updated")
+	assert.Equal(t, "zone-2", result[v1.LabelFailureDomainBetaZone], "beta zone label should be updated")
+	assert.Equal(t, "zone-1", result[xenorchestra.XOLabelTopologyOriginalHostID], "original host id should be set to previous zone")
+}
+
+func TestGetNodeLabelUpdate_ZoneChangedDoesNotOverrideOriginalHostIfExists(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-2",
+			Labels: map[string]string{
+				v1.LabelTopologyZone:                       "zone-1",
+				xenorchestra.XOLabelTopologyOriginalHostID: "already-present",
+			},
+		},
+		Spec: v1.NodeSpec{Taints: []v1.Taint{}},
+	}
+
+	meta := &cloudprovider.InstanceMetadata{Zone: "zone-3"}
+
+	result := getNodeLabelUpdate(node, meta)
+
+	assert.Equal(t, "zone-3", result[v1.LabelTopologyZone])
+	assert.Equal(t, "zone-3", result[v1.LabelFailureDomainBetaZone])
+	assert.NotContains(t, result, xenorchestra.XOLabelTopologyOriginalHostID, "should not override existing original host id label")
+}
+
+func TestGetNodeLabelUpdate_RegionChangedAddsOriginalPoolAndUpdatesLabels(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-3",
+			Labels: map[string]string{
+				v1.LabelTopologyRegion: "region-1",
+			},
+		},
+		Spec: v1.NodeSpec{Taints: []v1.Taint{}},
+	}
+
+	meta := &cloudprovider.InstanceMetadata{Region: "region-2"}
+
+	result := getNodeLabelUpdate(node, meta)
+
+	assert.Equal(t, "region-2", result[v1.LabelTopologyRegion], "region label should be updated")
+	assert.Equal(t, "region-2", result[v1.LabelFailureDomainBetaRegion], "beta region label should be updated")
+	assert.Equal(t, "region-1", result[xenorchestra.XOLabelTopologyOriginalPoolID], "original pool id should be set to previous region")
+}
+
+func TestGetNodeLabelUpdate_RegionChangedDoesNotOverrideOriginalPoolIfExists(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-4",
+			Labels: map[string]string{
+				v1.LabelTopologyRegion:                     "region-1",
+				xenorchestra.XOLabelTopologyOriginalPoolID: "already-present",
+			},
+		},
+		Spec: v1.NodeSpec{Taints: []v1.Taint{}},
+	}
+
+	meta := &cloudprovider.InstanceMetadata{Region: "region-3"}
+
+	result := getNodeLabelUpdate(node, meta)
+
+	assert.Equal(t, "region-3", result[v1.LabelTopologyRegion])
+	assert.Equal(t, "region-3", result[v1.LabelFailureDomainBetaRegion])
+	assert.NotContains(t, result, xenorchestra.XOLabelTopologyOriginalPoolID, "should not override existing original pool id label")
+}
+
+func TestGetNodeLabelUpdate_InstanceTypeChangedUpdatesBothLabels(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-5",
+			Labels: map[string]string{
+				v1.LabelInstanceTypeStable: "vm-type-1",
+			},
+		},
+		Spec: v1.NodeSpec{Taints: []v1.Taint{}},
+	}
+
+	meta := &cloudprovider.InstanceMetadata{InstanceType: "vm-type-2"}
+
+	result := getNodeLabelUpdate(node, meta)
+
+	assert.Equal(t, "vm-type-2", result[v1.LabelInstanceTypeStable], "stable instance type label should be updated")
+	assert.Equal(t, "vm-type-2", result[v1.LabelInstanceType], "beta instance type label should be updated")
+}
+
+func TestGetNodeLabelUpdate_NoChangesReturnsEmpty(t *testing.T) {
+	// Node has labels that already match metadata
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-6",
+			Labels: map[string]string{
+				v1.LabelTopologyZone:                          instanceMetadataTest.Zone,
+				v1.LabelTopologyRegion:                        instanceMetadataTest.Region,
+				v1.LabelInstanceTypeStable:                    instanceMetadataTest.InstanceType,
+				xenorchestra.XOLabelNamespace + "/test-label": instanceMetadataTest.AdditionalLabels[xenorchestra.XOLabelNamespace+"/test-label"],
+			},
+		},
+		Spec: v1.NodeSpec{Taints: []v1.Taint{}},
+	}
+
+	result := getNodeLabelUpdate(node, instanceMetadataTest)
+
+	assert.Equal(t, 0, len(result), "expected no label updates when nothing changed")
+}

--- a/pkg/controllers/nodelabelsync/helper_test.go
+++ b/pkg/controllers/nodelabelsync/helper_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/vatesfr/xenorchestra-cloud-controller-manager/pkg/xenorchestra"
 
 	v1 "k8s.io/api/core/v1"

--- a/pkg/controllers/nodelabelsync/helper_update_test.go
+++ b/pkg/controllers/nodelabelsync/helper_update_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2025 Vatesfr.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package nodelabelsync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vatesfr/xenorchestra-cloud-controller-manager/pkg/xenorchestra"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	cloudprovider "k8s.io/cloud-provider"
+)
+
+var testNode = &v1.Node{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "node-nochange",
+		Labels: map[string]string{
+			v1.LabelTopologyZone:                          "host-1",
+			v1.LabelTopologyRegion:                        "pool-1",
+			v1.LabelInstanceTypeStable:                    "2vCPU-2GB",
+			xenorchestra.XOLabelNamespace + "/test-label": "test-value",
+		},
+	},
+	Spec: v1.NodeSpec{Taints: []v1.Taint{}},
+}
+
+func drainEvents(rec *record.FakeRecorder, max int, wait time.Duration) []string {
+	events := []string{}
+	timeout := time.After(wait)
+	for {
+		select {
+		case e := <-rec.Events:
+			events = append(events, e)
+			if len(events) >= max {
+				return events
+			}
+		case <-timeout:
+			return events
+		}
+	}
+}
+
+func TestUpdateNodeLabels_NoChanges(t *testing.T) {
+	ctx := context.TODO()
+	client := k8sfake.NewClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	_, err := client.CoreV1().Nodes().Create(ctx, testNode, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to seed fake node: %v", err)
+	}
+
+	meta := &cloudprovider.InstanceMetadata{
+		Zone:         "host-1",
+		Region:       "pool-1",
+		InstanceType: "2vCPU-2GB",
+		AdditionalLabels: map[string]string{
+			xenorchestra.XOLabelNamespace + "/test-label": "test-value",
+		},
+	}
+
+	changed := updateNodeLabels(client, recorder, testNode, meta)
+	assert.False(t, changed, "expected no changes")
+
+	// Node labels should remain unchanged
+	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	assert.Equal(t, "host-1", got.Labels[v1.LabelTopologyZone])
+	assert.Equal(t, "pool-1", got.Labels[v1.LabelTopologyRegion])
+	assert.Equal(t, "2vCPU-2GB", got.Labels[v1.LabelInstanceTypeStable])
+	assert.Equal(t, "test-value", got.Labels[xenorchestra.XOLabelNamespace+"/test-label"])
+
+	// No events should be emitted
+	evs := drainEvents(recorder, 1, 150*time.Millisecond)
+	assert.Len(t, evs, 0, "expected no events")
+}
+
+func TestUpdateNodeLabels_ZoneChanged(t *testing.T) {
+	ctx := context.TODO()
+	client := k8sfake.NewClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	_, err := client.CoreV1().Nodes().Create(ctx, testNode, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to seed fake node: %v", err)
+	}
+
+	meta := &cloudprovider.InstanceMetadata{Zone: "host-2"}
+
+	changed := updateNodeLabels(client, recorder, testNode, meta)
+	assert.True(t, changed, "expected changes due to zone update")
+
+	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	assert.Equal(t, "host-2", got.Labels[v1.LabelTopologyZone])
+	assert.Equal(t, "host-2", got.Labels[v1.LabelFailureDomainBetaZone])
+	assert.Equal(t, "host-1", got.Labels[xenorchestra.XOLabelTopologyOriginalHostID])
+
+	evs := drainEvents(recorder, 1, 500*time.Millisecond)
+	if assert.Equal(t, len(evs), 1, "expected at least one event") {
+		// Fake recorder events are like: "TYPE REASON MESSAGE"
+		assert.Contains(t, evs[0], "NodeZoneChanged")
+		assert.Contains(t, evs[0], "Warning")
+		assert.Contains(t, evs[0], "old=host-1")
+		assert.Contains(t, evs[0], "new=host-2")
+	}
+}
+
+func TestUpdateNodeLabels_RegionChanged(t *testing.T) {
+	ctx := context.TODO()
+	client := k8sfake.NewClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	_, err := client.CoreV1().Nodes().Create(ctx, testNode, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to seed fake node: %v", err)
+	}
+
+	meta := &cloudprovider.InstanceMetadata{Region: "pool-2"}
+
+	changed := updateNodeLabels(client, recorder, testNode, meta)
+	assert.True(t, changed, "expected changes due to region update")
+
+	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	assert.Equal(t, "pool-2", got.Labels[v1.LabelTopologyRegion])
+	assert.Equal(t, "pool-2", got.Labels[v1.LabelFailureDomainBetaRegion])
+	assert.Equal(t, "pool-1", got.Labels[xenorchestra.XOLabelTopologyOriginalPoolID])
+
+	evs := drainEvents(recorder, 1, 500*time.Millisecond)
+	if assert.Equal(t, len(evs), 1, "expected at least one event") {
+		assert.Contains(t, evs[0], "NodeRegionChanged")
+		assert.Contains(t, evs[0], "Warning")
+		assert.Contains(t, evs[0], "old=pool-1")
+		assert.Contains(t, evs[0], "new=pool-2")
+	}
+}
+
+func TestUpdateNodeLabels_InstanceTypeChanged(t *testing.T) {
+	ctx := context.TODO()
+	client := k8sfake.NewClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	_, err := client.CoreV1().Nodes().Create(ctx, testNode, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to seed fake node: %v", err)
+	}
+
+	meta := &cloudprovider.InstanceMetadata{InstanceType: "2vCPU-4GB"}
+
+	changed := updateNodeLabels(client, recorder, testNode, meta)
+	assert.True(t, changed, "expected changes due to instance type update")
+
+	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	assert.Equal(t, "2vCPU-4GB", got.Labels[v1.LabelInstanceTypeStable])
+	assert.Equal(t, "2vCPU-4GB", got.Labels[v1.LabelInstanceType])
+
+	evs := drainEvents(recorder, 1, 500*time.Millisecond)
+	if assert.Equal(t, len(evs), 1, "expected at least one event") {
+		assert.Contains(t, evs[0], "NodeInstanceTypeHasChanged")
+		assert.Contains(t, evs[0], "Normal")
+		assert.Contains(t, evs[0], "old=2vCPU-2GB")
+		assert.Contains(t, evs[0], "new=2vCPU-4GB")
+	}
+}
+
+func TestUpdateNodeLabels_APIFailure(t *testing.T) {
+	ctx := context.TODO()
+	client := k8sfake.NewClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	// Make Node update/patch fail
+	failReactor := func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated API failure")
+	}
+	client.Fake.PrependReactor("patch", "nodes", failReactor)
+	client.Fake.PrependReactor("update", "nodes", failReactor)
+
+	_, err := client.CoreV1().Nodes().Create(ctx, testNode, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to seed fake node: %v", err)
+	}
+
+	meta := &cloudprovider.InstanceMetadata{Zone: "host-2"}
+
+	changed := updateNodeLabels(client, recorder, testNode, meta)
+	assert.False(t, changed, "expected failure to return false")
+
+	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	// Labels should not have been updated due to API error
+	assert.Equal(t, "host-1", got.Labels[v1.LabelTopologyZone])
+	assert.Empty(t, got.Labels[v1.LabelFailureDomainBetaZone])
+	assert.Empty(t, got.Labels[xenorchestra.XOLabelTopologyOriginalHostID])
+
+	// No events should be emitted when the API update fails
+	evs := drainEvents(recorder, 2, 200*time.Millisecond)
+	// Ensure none of the expected reasons are present
+	if len(evs) > 0 {
+		joined := strings.Join(evs, "\n")
+		assert.NotContains(t, joined, "NodeZoneChanged")
+		assert.NotContains(t, joined, "NodeRegionChanged")
+		assert.NotContains(t, joined, "NodeInstanceTypeHasChanged")
+	}
+}

--- a/pkg/controllers/nodelabelsync/helper_update_test.go
+++ b/pkg/controllers/nodelabelsync/helper_update_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/vatesfr/xenorchestra-cloud-controller-manager/pkg/xenorchestra"
 
 	v1 "k8s.io/api/core/v1"
@@ -205,8 +206,8 @@ func TestUpdateNodeLabels_APIFailure(t *testing.T) {
 	failReactor := func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("simulated API failure")
 	}
-	client.Fake.PrependReactor("patch", "nodes", failReactor)
-	client.Fake.PrependReactor("update", "nodes", failReactor)
+	client.PrependReactor("patch", "nodes", failReactor)
+	client.PrependReactor("update", "nodes", failReactor)
 
 	_, err := client.CoreV1().Nodes().Create(ctx, testNode, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/controllers/nodelabelsync/node_label_sync_controller.go
+++ b/pkg/controllers/nodelabelsync/node_label_sync_controller.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2025 Vatesfr.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package nodelabelsync
 
 import (


### PR DESCRIPTION
# Pull Request

## What? (description)

Record standard event at the node level when the VM that host the node changed of host, pool and type (CPU and memory limits)

## Why? (reasoning)

To track VM migration inside the k8s cluster and to be able to and respond to changes of this kind.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
