### PR TITLE
build: bump chart version - Use node DNS in the CCM pod

### DIFF
--- a/charts/xenorchestra-cloud-controller-manager/Chart.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/Chart.yaml
@@ -10,5 +10,5 @@ keywords:
   - ccm
   - xenorchestra
   - kubernetes
-version: 0.0.5
+version: 0.0.6
 appVersion: v0.2.0

--- a/charts/xenorchestra-cloud-controller-manager/README.md
+++ b/charts/xenorchestra-cloud-controller-manager/README.md
@@ -1,6 +1,6 @@
 # xenorchestra-cloud-controller-manager
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 Cloud Controller Manager plugin for Xen Orchestra
 
@@ -108,4 +108,3 @@ helm upgrade -i --namespace=kube-system -f xo-ccm.yaml \
 | affinity | object | `{}` | Affinity for data pods assignment. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | extraVolumes | list | `[]` | Additional volumes for Pods |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for Pods |
-| useHostNetwork | bool | `true` | Host networking requested for the CCM Pod |

--- a/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
@@ -35,10 +35,7 @@ spec:
       serviceAccountName: {{ include "xenorchestra-cloud-controller-manager.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.useHostNetwork }}
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
-      {{- end }}
+      dnsPolicy: Default
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/xenorchestra-cloud-controller-manager/values.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/values.yaml
@@ -148,6 +148,3 @@ extraVolumes: []
 
 # -- Additional volume mounts for Pods
 extraVolumeMounts: []
-
-# --  Host networking requested for the CCM Pod
-useHostNetwork: true

--- a/docs/deploy/cloud-controller-manager-edge.yml
+++ b/docs/deploy/cloud-controller-manager-edge.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: system:xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -136,8 +136,7 @@ spec:
         runAsGroup: 10258
         runAsNonRoot: true
         runAsUser: 10258
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      dnsPolicy: Default
       initContainers: []
       containers:
         - name: xenorchestra-cloud-controller-manager

--- a/docs/deploy/cloud-controller-manager-hostnetwork.yml
+++ b/docs/deploy/cloud-controller-manager-hostnetwork.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: system:xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -136,8 +136,7 @@ spec:
         runAsGroup: 10258
         runAsNonRoot: true
         runAsUser: 10258
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      dnsPolicy: Default
       initContainers: []
       containers:
         - name: xenorchestra-cloud-controller-manager

--- a/docs/deploy/cloud-controller-manager.yml
+++ b/docs/deploy/cloud-controller-manager.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: system:xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.5
+    helm.sh/chart: xenorchestra-cloud-controller-manager-0.0.6
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v0.2.0"
@@ -136,8 +136,7 @@ spec:
         runAsGroup: 10258
         runAsNonRoot: true
         runAsUser: 10258
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      dnsPolicy: Default
       initContainers: []
       containers:
         - name: xenorchestra-cloud-controller-manager


### PR DESCRIPTION

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Xen Orchestra CCM will first have to approve the PR.
-->

## What? (description)

Needs bump to fix the DNS used in the pod. 

## Why? (reasoning)

We need the pod to use the DNS of the host/node where it is running on, because at the init time of the cluster, the CoreDNS pod is not yet running.


## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
