### PR TITLE
revert removing of "use host network"

### DIFF
--- a/charts/xenorchestra-cloud-controller-manager/README.md
+++ b/charts/xenorchestra-cloud-controller-manager/README.md
@@ -108,3 +108,4 @@ helm upgrade -i --namespace=kube-system -f xo-ccm.yaml \
 | affinity | object | `{}` | Affinity for data pods assignment. ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | extraVolumes | list | `[]` | Additional volumes for Pods |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for Pods |
+| useHostNetwork | bool | `false` | Host networking requested for the CCM Pod |

--- a/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       dnsPolicy: Default
+      {{- if .Values.useHostNetwork }}
+      hostNetwork: true
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/xenorchestra-cloud-controller-manager/values.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/values.yaml
@@ -148,3 +148,6 @@ extraVolumes: []
 
 # -- Additional volume mounts for Pods
 extraVolumeMounts: []
+
+# --  Host networking requested for the CCM Pod
+useHostNetwork: false

--- a/docs/deploy/cloud-controller-manager-hostnetwork.yml
+++ b/docs/deploy/cloud-controller-manager-hostnetwork.yml
@@ -137,6 +137,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 10258
       dnsPolicy: Default
+      hostNetwork: true
       initContainers: []
       containers:
         - name: xenorchestra-cloud-controller-manager


### PR DESCRIPTION
# Pull Request

## What? (description)

Re-enabling the "use host network" option to allow the CCM to run on the node host network. 

## Why? (reasoning)

This is useful when the XO network cannot be reached from within the Kubernetes network.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
