### PR TITLE
fix(chart): add existingConfigSecretPath value to fix hardcoded mount path

### DIFF
--- a/charts/xenorchestra-cloud-controller-manager/Chart.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/Chart.yaml
@@ -10,5 +10,5 @@ keywords:
   - ccm
   - xenorchestra
   - kubernetes
-version: 1.0.0
+version: 1.0.1
 appVersion: v1.0.0

--- a/charts/xenorchestra-cloud-controller-manager/README.md
+++ b/charts/xenorchestra-cloud-controller-manager/README.md
@@ -1,6 +1,6 @@
 # xenorchestra-cloud-controller-manager
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v1.0.0-informational?style=flat-square)
 
 Cloud Controller Manager plugin for Xen Orchestra
 
@@ -103,6 +103,7 @@ helm upgrade -i --namespace=kube-system -f xo-ccm.yaml \
 | logVerbosityLevel | int | `2` |  |
 | existingConfigSecret | string | `nil` | Xen Orchestra cluster config stored in secrets. |
 | existingConfigSecretKey | string | `"config.yaml"` | Xen Orchestra cluster config stored in secrets key. |
+| existingConfigSecretPath | string | `"config.yaml"` | Xen Orchestra cluster config mount path inside the pod. |
 | config | string | `nil` | Xen Orchestra cluster config. |
 | serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Pods Service Account. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | priorityClassName | string | `"system-cluster-critical"` | CCM pods' priorityClassName. |

--- a/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
@@ -141,7 +141,7 @@ spec:
             secretName: {{ .Values.existingConfigSecret }}
             items:
               - key: {{ .Values.existingConfigSecretKey }}
-                path: xo-config.yaml
+                path: {{ .Values.existingConfigSecretPath }}
             defaultMode: 416
         {{- else }}
         - name: cloud-config

--- a/charts/xenorchestra-cloud-controller-manager/values.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/values.yaml
@@ -43,6 +43,8 @@ logVerbosityLevel: 2
 existingConfigSecret: ~
 # -- Xen Orchestra cluster config stored in secrets key.
 existingConfigSecretKey: config.yaml
+# -- Xen Orchestra cluster config mount path inside the pod.
+existingConfigSecretPath: config.yaml
 
 # -- Xen Orchestra cluster config.
 config:

--- a/docs/deploy/cloud-controller-manager-daemonset.yml
+++ b/docs/deploy/cloud-controller-manager-daemonset.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
@@ -18,58 +18,58 @@ kind: ClusterRole
 metadata:
   name: system:xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts/token
-  verbs:
-  - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
 ---
 # Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
 kind: ClusterRoleBinding
@@ -81,9 +81,9 @@ roleRef:
   kind: ClusterRole
   name: system:xenorchestra-cloud-controller-manager
 subjects:
-- kind: ServiceAccount
-  name: xenorchestra-cloud-controller-manager
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
 ---
 # Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -106,7 +106,7 @@ kind: DaemonSet
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
@@ -136,15 +136,14 @@ spec:
         runAsNonRoot: true
         runAsUser: 10258
       dnsPolicy: Default
-      initContainers:
-        []
+      initContainers: []
       containers:
         - name: xenorchestra-cloud-controller-manager
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             seccompProfile:
               type: RuntimeDefault
           image: "ghcr.io/vatesfr/xenorchestra-cloud-controller-manager:v1.0.0"

--- a/docs/deploy/cloud-controller-manager-edge.yml
+++ b/docs/deploy/cloud-controller-manager-edge.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
@@ -18,58 +18,58 @@ kind: ClusterRole
 metadata:
   name: system:xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts/token
-  verbs:
-  - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
 ---
 # Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
 kind: ClusterRoleBinding
@@ -81,9 +81,9 @@ roleRef:
   kind: ClusterRole
   name: system:xenorchestra-cloud-controller-manager
 subjects:
-- kind: ServiceAccount
-  name: xenorchestra-cloud-controller-manager
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
 ---
 # Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
@@ -137,15 +137,14 @@ spec:
         runAsNonRoot: true
         runAsUser: 10258
       dnsPolicy: Default
-      initContainers:
-        []
+      initContainers: []
       containers:
         - name: xenorchestra-cloud-controller-manager
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             seccompProfile:
               type: RuntimeDefault
           image: "ghcr.io/vatesfr/xenorchestra-cloud-controller-manager:edge"

--- a/docs/deploy/cloud-controller-manager-hostnetwork.yml
+++ b/docs/deploy/cloud-controller-manager-hostnetwork.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
@@ -18,58 +18,58 @@ kind: ClusterRole
 metadata:
   name: system:xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts/token
-  verbs:
-  - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
 ---
 # Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
 kind: ClusterRoleBinding
@@ -81,9 +81,9 @@ roleRef:
   kind: ClusterRole
   name: system:xenorchestra-cloud-controller-manager
 subjects:
-- kind: ServiceAccount
-  name: xenorchestra-cloud-controller-manager
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
 ---
 # Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
@@ -138,15 +138,14 @@ spec:
         runAsUser: 10258
       dnsPolicy: Default
       hostNetwork: true
-      initContainers:
-        []
+      initContainers: []
       containers:
         - name: xenorchestra-cloud-controller-manager
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             seccompProfile:
               type: RuntimeDefault
           image: "ghcr.io/vatesfr/xenorchestra-cloud-controller-manager:v1.0.0"

--- a/docs/deploy/cloud-controller-manager.yml
+++ b/docs/deploy/cloud-controller-manager.yml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
@@ -18,58 +18,58 @@ kind: ClusterRole
 metadata:
   name: system:xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts/token
-  verbs:
-  - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
 ---
 # Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
 kind: ClusterRoleBinding
@@ -81,9 +81,9 @@ roleRef:
   kind: ClusterRole
   name: system:xenorchestra-cloud-controller-manager
 subjects:
-- kind: ServiceAccount
-  name: xenorchestra-cloud-controller-manager
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
 ---
 # Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -106,7 +106,7 @@ kind: Deployment
 metadata:
   name: xenorchestra-cloud-controller-manager
   labels:
-    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.0
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
     app.kubernetes.io/name: xenorchestra-cloud-controller-manager
     app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
     app.kubernetes.io/version: "v1.0.0"
@@ -137,15 +137,14 @@ spec:
         runAsNonRoot: true
         runAsUser: 10258
       dnsPolicy: Default
-      initContainers:
-        []
+      initContainers: []
       containers:
         - name: xenorchestra-cloud-controller-manager
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             seccompProfile:
               type: RuntimeDefault
           image: "ghcr.io/vatesfr/xenorchestra-cloud-controller-manager:v1.0.0"


### PR DESCRIPTION
## Summary

- The volume item `path` in the Helm chart deployment template was hardcoded to `xo-config.yaml`, causing the config file to be mounted at `/etc/xenorchestra/xo-config.yaml` instead of the expected `/etc/xenorchestra/config.yaml`
- Adds a new `existingConfigSecretPath` value (default: `config.yaml`) to make the mount path configurable
- Fixes the CCM pod crash with `Couldn't open cloud provider configuration /etc/xenorchestra/config.yaml`

### Minor changes
- File formatting to match IDE formater