### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build-edge.yaml
+++ b/.github/workflows/build-edge.yaml
@@ -11,6 +11,7 @@ on:
       - 'cmd/**'
       - 'pkg/**'
       - 'Dockerfile'
+      - 'Makefile'
 
 jobs:
   build-publish:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,11 +10,12 @@ on:
       - 'cmd/**'
       - 'pkg/**'
       - 'Dockerfile'
+      - 'Makefile'
 
 jobs:
   build:
     name: Build
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,3 +38,8 @@ jobs:
       - name: Build
         timeout-minutes: 10
         run: make build
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build image
+        timeout-minutes: 10
+        run: VERSION=v0.0.0-test make images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.15
 ########################################
 
-FROM --platform=${BUILDPLATFORM} golang:1.25.8-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.26.0-alpine AS builder
 RUN apk update && apk add --no-cache make
 ENV GO111MODULE=on
 WORKDIR /src


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Xen Orchestra CCM will first have to approve the PR.
-->

## What? (description)

The previous MR #58 made the docker build fail. It has not been seen at the review. I fixed the error and purpose to add the check to the CI at each necessary build.

## Why? (reasoning)

Upgrading go.mod version can make docker image build fail
Upgrading make file can lead to false positive also

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
