### PR TITLE
feat: add event when initialization fail

### DIFF
--- a/charts/xenorchestra-cloud-controller-manager/Chart.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/Chart.yaml
@@ -10,5 +10,5 @@ keywords:
   - ccm
   - xenorchestra
   - kubernetes
-version: 1.0.1
-appVersion: v1.0.0
+version: 1.1.0
+appVersion: v1.1.0

--- a/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
@@ -74,8 +74,20 @@ spec:
           {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.extraEnvs }}
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:

--- a/charts/xenorchestra-cloud-controller-manager/templates/role.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/role.yaml
@@ -22,6 +22,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
   - ""
   resources:
   - nodes

--- a/docs/deploy/cloud-controller-manager-daemonset.yml
+++ b/docs/deploy/cloud-controller-manager-daemonset.yml
@@ -41,6 +41,14 @@ rules:
       - patch
       - update
   - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - ""
     resources:
       - nodes
@@ -157,6 +165,19 @@ spec:
             - --use-service-account-credentials
             - --secure-port=10258
             - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           ports:
             - name: metrics
               containerPort: 10258

--- a/docs/deploy/cloud-controller-manager-edge.yml
+++ b/docs/deploy/cloud-controller-manager-edge.yml
@@ -41,6 +41,14 @@ rules:
       - patch
       - update
   - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - ""
     resources:
       - nodes
@@ -159,6 +167,19 @@ spec:
             - --secure-port=10258
             - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
             - --leader-elect=false
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           ports:
             - name: metrics
               containerPort: 10258

--- a/docs/deploy/cloud-controller-manager-hostnetwork.yml
+++ b/docs/deploy/cloud-controller-manager-hostnetwork.yml
@@ -41,6 +41,14 @@ rules:
       - patch
       - update
   - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - ""
     resources:
       - nodes
@@ -160,6 +168,19 @@ spec:
             - --secure-port=10258
             - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
             - --leader-elect=false
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           ports:
             - name: metrics
               containerPort: 10258

--- a/docs/deploy/cloud-controller-manager.yml
+++ b/docs/deploy/cloud-controller-manager.yml
@@ -41,6 +41,14 @@ rules:
       - patch
       - update
   - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - ""
     resources:
       - nodes
@@ -159,6 +167,19 @@ spec:
             - --secure-port=10258
             - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
             - --leader-elect=false
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           ports:
             - name: metrics
               containerPort: 10258

--- a/pkg/xenorchestra/cloud.go
+++ b/pkg/xenorchestra/cloud.go
@@ -19,10 +19,21 @@ package xenorchestra
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"io"
+	"os"
+	"time"
 
 	xok8s "github.com/vatesfr/xenorchestra-k8s-common"
 
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 )
@@ -33,6 +44,15 @@ const (
 
 	// ServiceAccountName is the service account name used in kube-system namespace.
 	ServiceAccountName = xok8s.ProviderName + "-cloud-controller-manager"
+
+	cloudControllerManagerClientName = "xenorchestra-cloud-controller-manager"
+	componentKind                    = "Component"
+	podKind                          = "Pod"
+	podNameEnv                       = "POD_NAME"
+	podNamespaceEnv                  = "POD_NAMESPACE"
+	podUIDEnv                        = "POD_UID"
+	eventActionCheckClient           = "CheckClient"
+	eventReasonFailedToCheckClient   = "FailedToCheckClient"
 )
 
 type cloud struct {
@@ -84,6 +104,11 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	err := c.client.CheckClient(ctx)
 	if err != nil {
 		klog.ErrorS(err, "failed to check Xen Orchestra client")
+		kubeClient := clientBuilder.ClientOrDie(cloudControllerManagerClientName)
+		if eventErr := recordCloudProviderInitializationFailure(ctx, kubeClient, err); eventErr != nil {
+			klog.ErrorS(eventErr, "failed to record Xen Orchestra client check failure event")
+		}
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
 	// Broadcast the upstream stop signal to all provider-level goroutines
@@ -95,6 +120,101 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	}(c)
 
 	klog.InfoS("Xen Orchestra client initialized")
+}
+
+func recordCloudProviderInitializationFailure(ctx context.Context, kubeClient clientset.Interface, err error) error {
+	eventTime := metav1.MicroTime{Time: time.Now()}
+	regarding := cloudProviderEventObjectReference()
+	event := &eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cloudProviderEventName(regarding),
+			Namespace: cloudProviderEventNamespace(),
+		},
+		EventTime:           eventTime,
+		ReportingController: ProviderName,
+		ReportingInstance:   cloudProviderEventReportingInstance(),
+		Action:              eventActionCheckClient,
+		Reason:              eventReasonFailedToCheckClient,
+		Regarding:           regarding,
+		Note:                fmt.Sprintf("Failed to check Xen Orchestra client: %v", err),
+		Type:                corev1.EventTypeWarning,
+	}
+
+	eventsClient := kubeClient.EventsV1().Events(cloudProviderEventNamespace())
+	if _, createErr := eventsClient.Create(ctx, event, metav1.CreateOptions{}); createErr != nil {
+		if !apierrors.IsAlreadyExists(createErr) {
+			return createErr
+		}
+
+		existingEvent, getErr := eventsClient.Get(ctx, event.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+
+		event.ResourceVersion = existingEvent.ResourceVersion
+		event.EventTime = existingEvent.EventTime
+		event.Series = &eventsv1.EventSeries{
+			Count:            2,
+			LastObservedTime: eventTime,
+		}
+		if existingEvent.Series != nil {
+			event.Series.Count = existingEvent.Series.Count + 1
+		}
+
+		_, updateErr := eventsClient.Update(ctx, event, metav1.UpdateOptions{})
+		return updateErr
+	}
+
+	return nil
+}
+
+func cloudProviderEventName(regarding corev1.ObjectReference) string {
+	hashInput := fmt.Sprintf("%s/%s/%s/%s/%s/%s",
+		regarding.Namespace,
+		regarding.Kind,
+		regarding.Name,
+		regarding.UID,
+		eventActionCheckClient,
+		eventReasonFailedToCheckClient,
+	)
+	hash := sha256.Sum256([]byte(hashInput))
+
+	return fmt.Sprintf("%s-%s", ProviderName, hex.EncodeToString(hash[:])[:12])
+}
+
+func cloudProviderEventObjectReference() corev1.ObjectReference {
+	if podName := os.Getenv(podNameEnv); podName != "" {
+		return corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       podKind,
+			Namespace:  cloudProviderEventNamespace(),
+			Name:       podName,
+			UID:        types.UID(os.Getenv(podUIDEnv)),
+		}
+	}
+
+	return corev1.ObjectReference{
+		APIVersion: "v1",
+		Kind:       componentKind,
+		Namespace:  cloudProviderEventNamespace(),
+		Name:       ProviderName,
+	}
+}
+
+func cloudProviderEventNamespace() string {
+	if podNamespace := os.Getenv(podNamespaceEnv); podNamespace != "" {
+		return podNamespace
+	}
+
+	return metav1.NamespaceSystem
+}
+
+func cloudProviderEventReportingInstance() string {
+	if podName := os.Getenv(podNameEnv); podName != "" {
+		return podName
+	}
+
+	return cloudControllerManagerClientName
 }
 
 // LoadBalancer returns a balancer interface.

--- a/pkg/xenorchestra/cloud_test.go
+++ b/pkg/xenorchestra/cloud_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package xenorchestra
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	xok8s "github.com/vatesfr/xenorchestra-k8s-common"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestNewCloudError(t *testing.T) {
@@ -74,4 +79,69 @@ token: "12ABC"
 
 	clID := cloud.HasClusterID()
 	assert.Equal(t, clID, true)
+}
+
+func TestRecordCloudProviderInitializationFailure(t *testing.T) {
+	client := fake.NewClientset()
+
+	err := recordCloudProviderInitializationFailure(t.Context(), client, errors.New("tls: failed to verify certificate"))
+	assert.NoError(t, err)
+
+	events, err := client.EventsV1().Events(metav1.NamespaceSystem).List(t.Context(), metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, events.Items, 1)
+
+	event := events.Items[0]
+	assert.Equal(t, corev1.EventTypeWarning, event.Type)
+	assert.Equal(t, eventActionCheckClient, event.Action)
+	assert.Equal(t, eventReasonFailedToCheckClient, event.Reason)
+	assert.Contains(t, event.Note, "tls: failed to verify certificate")
+	assert.Equal(t, ProviderName, event.ReportingController)
+	assert.Equal(t, cloudControllerManagerClientName, event.ReportingInstance)
+	assert.Equal(t, metav1.NamespaceSystem, event.Regarding.Namespace)
+	assert.Equal(t, ProviderName, event.Regarding.Name)
+	assert.Equal(t, componentKind, event.Regarding.Kind)
+	assert.Nil(t, event.Series)
+}
+
+func TestRecordCloudProviderInitializationFailureUsesPodReference(t *testing.T) {
+	t.Setenv(podNameEnv, "xoccm-123")
+	t.Setenv(podNamespaceEnv, "custom-system")
+	t.Setenv(podUIDEnv, "87db141c-8f50-4b8e-9d23-0c8de730216a")
+
+	client := fake.NewClientset()
+
+	err := recordCloudProviderInitializationFailure(t.Context(), client, errors.New("tls: failed to verify certificate"))
+	assert.NoError(t, err)
+
+	events, err := client.EventsV1().Events("custom-system").List(t.Context(), metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, events.Items, 1)
+
+	event := events.Items[0]
+	assert.Equal(t, "custom-system", event.Namespace)
+	assert.Equal(t, "custom-system", event.Regarding.Namespace)
+	assert.Equal(t, "xoccm-123", event.Regarding.Name)
+	assert.Equal(t, podKind, event.Regarding.Kind)
+	assert.Equal(t, "87db141c-8f50-4b8e-9d23-0c8de730216a", string(event.Regarding.UID))
+	assert.Equal(t, "xoccm-123", event.ReportingInstance)
+}
+
+func TestRecordCloudProviderInitializationFailureUpdatesExistingEventSeries(t *testing.T) {
+	t.Setenv(podNameEnv, "xoccm-123")
+	t.Setenv(podNamespaceEnv, "custom-system")
+	t.Setenv(podUIDEnv, "87db141c-8f50-4b8e-9d23-0c8de730216a")
+
+	client := fake.NewClientset()
+
+	err := recordCloudProviderInitializationFailure(t.Context(), client, errors.New("tls: failed to verify certificate"))
+	assert.NoError(t, err)
+	err = recordCloudProviderInitializationFailure(t.Context(), client, errors.New("tls: failed to verify certificate"))
+	assert.NoError(t, err)
+
+	events, err := client.EventsV1().Events("custom-system").List(t.Context(), metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, events.Items, 1)
+	assert.NotNil(t, events.Items[0].Series)
+	assert.Equal(t, int32(2), events.Items[0].Series.Count)
 }


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Xen Orchestra CCM will first have to approve the PR.
-->

Closes #48 

## Why? (reasoning)

When an error occur at initialization, such as an insecure connection, there is no specific detail in pod to know why, people need to go into logs details, and that's not very user friendly. A pattern is to create a kubernetes event.

## What? (description)

- Create an event when error occurs at initialization
- If the same error has already be thrown recently, increment this series

## Acceptance

<img width="1885" height="135" alt="image" src="https://github.com/user-attachments/assets/a09ddec4-e26a-4bb7-821b-6cc221106480" />

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [X] you included tests (if applicable)
- [X] you linted your code (`make lint`)
- [X] you tested your code (`make unit`)

> See `make help` for a description of the available targets.
