### PR TITLE
Feat/xo config env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,30 @@ The CCM maps Kubernetes topology labels to Xen Orchestra objects:
 
 ## 🧩 Configuration
 
+### Using a config file
+
+You can provide a configuration file to the CCM using the `--cloud-config` flag. Example:
+
 ```yaml
 # config.yaml
 # URL of the Xen Orchestra API (http or https)
 url: https://xoa.example.com
 insecure: false
-
-# Authentication (choose one)
 token: "123ABC"
-# username: admin@admin.net
-# password: "s3cret"
 ```
 
-* Either `token` **or** `username`/`password` is required.
+* `token` is required.
 * `url` must include a scheme; set `insecure: true` only when you explicitly want to skip TLS verification.
+
+### Using environment variables
+
+You can also provide configuration via environment variables:
+
+| Environment variable | Description |
+|----------------------|-------------|
+| `XOA_URL` | URL of the Xen Orchestra API (http or https) |
+| `XOA_TOKEN` | API token for authentication |
+| `XOA_INSECURE` | Whether to skip TLS verification |
 
 ## 📌 Node labels and providerID
 

--- a/charts/xenorchestra-cloud-controller-manager/Chart.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/Chart.yaml
@@ -10,5 +10,5 @@ keywords:
   - ccm
   - xenorchestra
   - kubernetes
-version: 1.0.1
-appVersion: v1.0.0
+version: 1.1.0
+appVersion: v1.1.0

--- a/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
@@ -62,7 +62,9 @@ spec:
           args:
             - --v={{ .Values.logVerbosityLevel }}
             - --cloud-provider=xenorchestra
+            {{- if .Values.config }}
             - --cloud-config=/etc/xenorchestra/config.yaml
+            {{- end }}
             - --controllers={{- trimAll "," (include "xenorchestra-cloud-controller-manager.enabledControllers" . ) }}
             - --leader-elect-resource-name=cloud-controller-manager-xenorchestra
             - --use-service-account-credentials
@@ -92,13 +94,17 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.config .Values.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.config }}
             - name: cloud-config
               mountPath: /etc/xenorchestra
               readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -134,7 +140,9 @@ spec:
             matchLabels:
               {{- include "xenorchestra-cloud-controller-manager.selectorLabels" . | nindent 14 }}
       {{- end }}
+      {{- if or .Values.config .Values.extraVolumes }}
       volumes:
+        {{- if .Values.config }}
         {{- if .Values.existingConfigSecret }}
         - name: cloud-config
           secret:
@@ -149,6 +157,8 @@ spec:
             secretName: {{ include "xenorchestra-cloud-controller-manager.fullname" . }}
             defaultMode: 416
         {{- end }}
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}

--- a/charts/xenorchestra-cloud-controller-manager/values.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/values.yaml
@@ -22,7 +22,14 @@ extraEnvs: []
   #   value: 127.0.0.1
 
 # -- Any extra arguments for xenorchestra-cloud-controller-manager
-extraArgs: []
+# -- You can also configure Xen-Orchestra values env variables instead of using a config file.
+extraArgs: [
+  # -- Url the Xen Orchestra API
+  "XOA_URL": "http://xoa-main.cogent1.vates.team",
+  "XOA_INSECURE": "true",
+  # -- Token for Xen Orchestra API
+  "XOA_TOKEN": "123ABC",
+]
 # --cluster-name=kubernetes
 
 # -- List of controllers should be enabled.
@@ -47,11 +54,13 @@ existingConfigSecretKey: config.yaml
 existingConfigSecretPath: config.yaml
 
 # -- Xen Orchestra cluster config.
+# You can provide a necessary configuration for the CCM using a config file.
+# It will be stored in a secret and mounted inside the CCM pod.
 config:
   # -- Url the Xen Orchestra API
   # url: https://xoa.example.com
   # insecure: false
-  # -- Token for ta Xen Orchestra API
+  # -- Token for Xen Orchestra API
   # token: "123ABC"
 
 # -- Pods Service Account.

--- a/docs/deploy/cloud-controller-manager-envfrom-secret.yml
+++ b/docs/deploy/cloud-controller-manager-envfrom-secret.yml
@@ -1,0 +1,219 @@
+---
+# Example: Xen Orchestra configuration loaded from environment variables.
+#
+# This manifest starts the CCM without --cloud-config, so it reads the XOA_*
+# variables injected from the xenorchestra-config secret below.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: xenorchestra-config
+  namespace: kube-system
+type: Opaque
+stringData:
+  XOA_URL: "https://xoa.example.com"
+  XOA_TOKEN: "123ABC"
+  XOA_INSECURE: "false"
+---
+# Source: xenorchestra-cloud-controller-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v1.0.0"
+    app.kubernetes.io/managed-by: Helm
+  namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v1.0.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+---
+# Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:xenorchestra-cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:xenorchestra-cloud-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:xenorchestra-cloud-controller-manager:extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: xenorchestra-cloud-controller-manager
+    namespace: kube-system
+---
+# Source: xenorchestra-cloud-controller-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xenorchestra-cloud-controller-manager
+  labels:
+    helm.sh/chart: xenorchestra-cloud-controller-manager-1.0.1
+    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    app.kubernetes.io/version: "v1.0.0"
+    app.kubernetes.io/managed-by: Helm
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+      app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+        app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+    spec:
+      enableServiceLinks: false
+      priorityClassName: system-cluster-critical
+      serviceAccountName: xenorchestra-cloud-controller-manager
+      securityContext:
+        fsGroup: 10258
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 10258
+        runAsNonRoot: true
+        runAsUser: 10258
+      dnsPolicy: Default
+      initContainers: []
+      containers:
+        - name: xenorchestra-cloud-controller-manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/vatesfr/xenorchestra-cloud-controller-manager:v1.0.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --cloud-provider=xenorchestra
+            - --controllers=cloud-node,cloud-node-lifecycle,cloud-node-label-sync
+            - --leader-elect-resource-name=cloud-controller-manager-xenorchestra
+            - --use-service-account-credentials
+            - --secure-port=10258
+            - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
+            - --leader-elect=false
+          envFrom:
+            - secretRef:
+                name: xenorchestra-config
+          ports:
+            - name: metrics
+              containerPort: 10258
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+                    app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+                topologyKey: topology.kubernetes.io/zone
+              weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: xenorchestra-cloud-controller-manager
+              app.kubernetes.io/instance: xenorchestra-cloud-controller-manager

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/vatesfr/xenorchestra-go-sdk v1.15.1
-	github.com/vatesfr/xenorchestra-k8s-common v0.1.0
+	github.com/vatesfr/xenorchestra-k8s-common v0.2.0
 	go.uber.org/mock v0.6.0
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/vatesfr/xenorchestra-go-sdk v1.15.1 h1:jBST0y5XC+AtytM8sWJLs7cs2zNsCPanhTpKAzfhj3g=
 github.com/vatesfr/xenorchestra-go-sdk v1.15.1/go.mod h1:fTF8G7F6f6145Ekv1NQI/S9zVRoAmW0xZnFAymU9Pjg=
-github.com/vatesfr/xenorchestra-k8s-common v0.1.0 h1:VF9sDftxOKW8xc8kxGmX/4Idjud5T3hf1IdixieXilM=
-github.com/vatesfr/xenorchestra-k8s-common v0.1.0/go.mod h1:o/LRNwZ9LEZlepephpWttXjl0LcRdHHHdP3cinTBvug=
+github.com/vatesfr/xenorchestra-k8s-common v0.2.0 h1:o1wg0pAQs4EkZWtGByUSm38J1diBwxjypGQkScvRHqo=
+github.com/vatesfr/xenorchestra-k8s-common v0.2.0/go.mod h1:o/LRNwZ9LEZlepephpWttXjl0LcRdHHHdP3cinTBvug=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chqDkyE9Z4N61UnQd+KOfgp5Iu53llk=

--- a/pkg/xenorchestra/cloud.go
+++ b/pkg/xenorchestra/cloud.go
@@ -45,9 +45,20 @@ type cloud struct {
 
 func init() {
 	cloudprovider.RegisterCloudProvider(xok8s.ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
-		cfg, err := xok8s.ReadCloudConfig(config)
+		if config != nil {
+			cfg, err := xok8s.ReadCloudConfig(config)
+			if err != nil {
+				klog.ErrorS(err, "failed to read config")
+
+				return nil, err
+			}
+
+			return newCloud(&cfg)
+		}
+
+		cfg, err := xok8s.LoadXOConfigFromEnv()
 		if err != nil {
-			klog.ErrorS(err, "failed to read config")
+			klog.ErrorS(err, "failed to read config from environment")
 
 			return nil, err
 		}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Xen Orchestra CCM will first have to approve the PR.
-->



## Why? (reasoning)

It's currently not possible to configure ccm using env var

## What? (description)

You can now choose to use cloud-config file or giving it by env var. It prioritize config file over env values

## Acceptance

Note: I cannot test unit test this function because it's a lambda function in an init function

Tested by running and using different configurations on kubernetes
config flag -> OK
env var -> OK
config flag + env var -> choosing config file
None -> KO

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you linted your code (`make lint`)
- [X] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
