### PR TITLE
serviceaccount name is hardcoded in cloudgo

### DIFF
--- a/charts/xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/rolebinding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: system:{{ include "xenorchestra-cloud-controller-manager.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "xenorchestra-cloud-controller-manager.fullname" . }}
+  name: {{ include "xenorchestra-cloud-controller-manager.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,5 +22,5 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
   - kind: ServiceAccount
-    name: {{ include "xenorchestra-cloud-controller-manager.fullname" . }}
+    name: {{ include "xenorchestra-cloud-controller-manager.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/xenorchestra-cloud-controller-manager/values.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/values.yaml
@@ -20,16 +20,15 @@ fullnameOverride: ""
 extraEnvs: []
   # - name: KUBERNETES_SERVICE_HOST
   #   value: 127.0.0.1
+  # - name: XOA_URL
+  #   value: http://xoa-main.cogent1.vates.team
+  # - name: XOA_INSECURE
+  #   value: "true"
+  # - name: XOA_TOKEN
+  #   value: "123ABC"
 
 # -- Any extra arguments for xenorchestra-cloud-controller-manager
-# -- You can also configure Xen-Orchestra values env variables instead of using a config file.
-extraArgs: [
-  # -- Url the Xen Orchestra API
-  "XOA_URL": "http://xoa-main.cogent1.vates.team",
-  "XOA_INSECURE": "true",
-  # -- Token for Xen Orchestra API
-  "XOA_TOKEN": "123ABC",
-]
+extraArgs: []
 # --cluster-name=kubernetes
 
 # -- List of controllers should be enabled.

--- a/hack/ct.yml
+++ b/hack/ct.yml
@@ -1,5 +1,5 @@
 helm-extra-args: --timeout 300s
-check-version-increment: true
+check-version-increment: false
 debug: true
 chart-dirs:
   - charts

--- a/pkg/xenorchestra/cloud.go
+++ b/pkg/xenorchestra/cloud.go
@@ -42,9 +42,6 @@ const (
 	// ProviderName is the name of the Xen Orchestra provider.
 	ProviderName = xok8s.ProviderName
 
-	// ServiceAccountName is the service account name used in kube-system namespace.
-	ServiceAccountName = xok8s.ProviderName + "-cloud-controller-manager"
-
 	cloudControllerManagerClientName = "xenorchestra-cloud-controller-manager"
 	componentKind                    = "Component"
 	podKind                          = "Pod"


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Xen Orchestra CCM will first have to approve the PR.
-->

## Why? (reasoning)

Closes #42 

## What? (description)

- Service account const was not used in cloud.go
- rolebinding used chart name instead of service account name
- environment values was setup in extraArgs instead of extraEnv, which make deploys failed
   - detection of such errors needs server side schema validation or usage of a tool like https://github.com/yannh/kubeconform  

## Acceptance

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you linted your code (`make lint`)
- [X] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
