### PR TITLE
fix(chart): default values now use an existing secret to fix deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,16 +112,20 @@ docs:
 	yq -i '.appVersion = "$(TAG)"' charts/xenorchestra-cloud-controller-manager/Chart.yaml -y
 	helm template -n kube-system xenorchestra-cloud-controller-manager \
 		-f charts/xenorchestra-cloud-controller-manager/values.hostnetwork.yaml \
+		--set existingConfigSecret=xenorchestra-cloud-controller-manager \
 		charts/xenorchestra-cloud-controller-manager > docs/deploy/cloud-controller-manager-hostnetwork.yml
 	helm template -n kube-system xenorchestra-cloud-controller-manager \
 		-f charts/xenorchestra-cloud-controller-manager/values.edge.yaml \
+		--set existingConfigSecret=xenorchestra-cloud-controller-manager \
 		charts/xenorchestra-cloud-controller-manager > docs/deploy/cloud-controller-manager-edge.yml
 	helm template -n kube-system xenorchestra-cloud-controller-manager \
 		--set-string image.tag=$(TAG) \
+		--set existingConfigSecret=xenorchestra-cloud-controller-manager \
 		charts/xenorchestra-cloud-controller-manager > docs/deploy/cloud-controller-manager.yml
 	helm template -n kube-system xenorchestra-cloud-controller-manager \
 		--set-string image.tag=$(TAG) \
 		--set useDaemonSet=true \
+		--set existingConfigSecret=xenorchestra-cloud-controller-manager \
 		charts/xenorchestra-cloud-controller-manager > docs/deploy/cloud-controller-manager-daemonset.yml
 	helm-docs --sort-values-order=file charts/xenorchestra-cloud-controller-manager
 

--- a/charts/xenorchestra-cloud-controller-manager/README.md
+++ b/charts/xenorchestra-cloud-controller-manager/README.md
@@ -101,7 +101,7 @@ helm upgrade -i --namespace=kube-system -f xo-ccm.yaml \
 | extraArgs | list | `[]` | Any extra arguments for xenorchestra-cloud-controller-manager |
 | enabledControllers | list | `["cloud-node","cloud-node-lifecycle","cloud-node-label-sync"]` | List of controllers should be enabled. Use '*' to enable all controllers. Support only `cloud-node,cloud-node-lifecycle,cloud-node-label-sync` controllers. |
 | logVerbosityLevel | int | `2` |  |
-| existingConfigSecret | string | `nil` | Xen Orchestra cluster config stored in secrets. |
+| existingConfigSecret | string | `"xenorchestra-cloud-controller-manager"` | Xen Orchestra cluster config stored in secrets. |
 | existingConfigSecretKey | string | `"config.yaml"` | Xen Orchestra cluster config stored in secrets key. |
 | existingConfigSecretPath | string | `"config.yaml"` | Xen Orchestra cluster config mount path inside the pod. |
 | config | string | `nil` | Xen Orchestra cluster config. You can provide a necessary configuration for the CCM using a config file. It will be stored in a secret and mounted inside the CCM pod. |

--- a/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/xenorchestra-cloud-controller-manager/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           args:
             - --v={{ .Values.logVerbosityLevel }}
             - --cloud-provider=xenorchestra
-            {{- if .Values.config }}
+            {{- if or .Values.config .Values.existingConfigSecret }}
             - --cloud-config=/etc/xenorchestra/config.yaml
             {{- end }}
             - --controllers={{- trimAll "," (include "xenorchestra-cloud-controller-manager.enabledControllers" . ) }}
@@ -106,9 +106,9 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.config .Values.extraVolumeMounts }}
+          {{- if or .Values.config .Values.existingConfigSecret .Values.extraVolumeMounts }}
           volumeMounts:
-            {{- if .Values.config }}
+            {{- if or .Values.config .Values.existingConfigSecret }}
             - name: cloud-config
               mountPath: /etc/xenorchestra
               readOnly: true
@@ -152,9 +152,8 @@ spec:
             matchLabels:
               {{- include "xenorchestra-cloud-controller-manager.selectorLabels" . | nindent 14 }}
       {{- end }}
-      {{- if or .Values.config .Values.extraVolumes }}
+      {{- if or .Values.config .Values.existingConfigSecret .Values.extraVolumes }}
       volumes:
-        {{- if .Values.config }}
         {{- if .Values.existingConfigSecret }}
         - name: cloud-config
           secret:
@@ -163,12 +162,11 @@ spec:
               - key: {{ .Values.existingConfigSecretKey }}
                 path: {{ .Values.existingConfigSecretPath }}
             defaultMode: 416
-        {{- else }}
+        {{- else if .Values.config }}
         - name: cloud-config
           secret:
             secretName: {{ include "xenorchestra-cloud-controller-manager.fullname" . }}
             defaultMode: 416
-        {{- end }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/docs/deploy/cloud-controller-manager-daemonset.yml
+++ b/docs/deploy/cloud-controller-manager-daemonset.yml
@@ -163,6 +163,7 @@ spec:
           args:
             - --v=2
             - --cloud-provider=xenorchestra
+            - --cloud-config=/etc/xenorchestra/config.yaml
             - --controllers=cloud-node,cloud-node-lifecycle,cloud-node-label-sync
             - --leader-elect-resource-name=cloud-controller-manager-xenorchestra
             - --use-service-account-credentials
@@ -197,6 +198,10 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /etc/xenorchestra
+              readOnly: true
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -217,3 +222,11 @@ spec:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
           operator: Exists
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: xenorchestra-cloud-controller-manager
+            items:
+              - key: config.yaml
+                path: config.yaml
+            defaultMode: 416

--- a/docs/deploy/cloud-controller-manager-edge.yml
+++ b/docs/deploy/cloud-controller-manager-edge.yml
@@ -164,6 +164,7 @@ spec:
           args:
             - --v=4
             - --cloud-provider=xenorchestra
+            - --cloud-config=/etc/xenorchestra/config.yaml
             - --controllers=cloud-node,cloud-node-lifecycle,cloud-node-label-sync
             - --leader-elect-resource-name=cloud-controller-manager-xenorchestra
             - --use-service-account-credentials
@@ -199,6 +200,10 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /etc/xenorchestra
+              readOnly: true
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -224,3 +229,11 @@ spec:
             matchLabels:
               app.kubernetes.io/name: xenorchestra-cloud-controller-manager
               app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: xenorchestra-cloud-controller-manager
+            items:
+              - key: config.yaml
+                path: config.yaml
+            defaultMode: 416

--- a/docs/deploy/cloud-controller-manager-hostnetwork.yml
+++ b/docs/deploy/cloud-controller-manager-hostnetwork.yml
@@ -165,6 +165,7 @@ spec:
           args:
             - --v=2
             - --cloud-provider=xenorchestra
+            - --cloud-config=/etc/xenorchestra/config.yaml
             - --controllers=cloud-node,cloud-node-lifecycle,cloud-node-label-sync
             - --leader-elect-resource-name=cloud-controller-manager-xenorchestra
             - --use-service-account-credentials
@@ -200,6 +201,10 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /etc/xenorchestra
+              readOnly: true
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -225,3 +230,11 @@ spec:
             matchLabels:
               app.kubernetes.io/name: xenorchestra-cloud-controller-manager
               app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: xenorchestra-cloud-controller-manager
+            items:
+              - key: config.yaml
+                path: config.yaml
+            defaultMode: 416

--- a/docs/deploy/cloud-controller-manager.yml
+++ b/docs/deploy/cloud-controller-manager.yml
@@ -164,6 +164,7 @@ spec:
           args:
             - --v=2
             - --cloud-provider=xenorchestra
+            - --cloud-config=/etc/xenorchestra/config.yaml
             - --controllers=cloud-node,cloud-node-lifecycle,cloud-node-label-sync
             - --leader-elect-resource-name=cloud-controller-manager-xenorchestra
             - --use-service-account-credentials
@@ -199,6 +200,10 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+          volumeMounts:
+            - name: cloud-config
+              mountPath: /etc/xenorchestra
+              readOnly: true
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -224,3 +229,11 @@ spec:
             matchLabels:
               app.kubernetes.io/name: xenorchestra-cloud-controller-manager
               app.kubernetes.io/instance: xenorchestra-cloud-controller-manager
+      volumes:
+        - name: cloud-config
+          secret:
+            secretName: xenorchestra-cloud-controller-manager
+            items:
+              - key: config.yaml
+                path: config.yaml
+            defaultMode: 416

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,13 +58,13 @@ Alternatively, you can use a Xen Orchestra username/password pair in `config.yam
 
 ## Deploy CCM
 
+### Method 1: kubectl
+
 Create the Xen Orchestra credentials config file `config.yaml` (see the example above) and store it as a secret:
 
 ```shell
 kubectl -n kube-system create secret generic xenorchestra-cloud-controller-manager --from-file=config.yaml
 ```
-
-### Method 1: kubectl
 
 Deploy the CCM manifest:
 


### PR DESCRIPTION
## What? (description)

This PR set a default value for `existingConfigSecret` to match the installation documentation (section **Method 1: kubectl**)

Fixes #74 

## Why? (reasoning)

After the previous changes to _Allow usage of env var instead of secret config file for xo config_, the volume mount for the secret was removed from the deployments.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
