### PR TITLE
fix(nodelabelsync): persist missing providerID on nodes

### DIFF
--- a/pkg/controllers/nodelabelsync/helper.go
+++ b/pkg/controllers/nodelabelsync/helper.go
@@ -16,13 +16,16 @@ limitations under the License.
 package nodelabelsync
 
 import (
+	"context"
 	"strings"
 
 	xok8s "github.com/vatesfr/xenorchestra-k8s-common"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	clientretry "k8s.io/client-go/util/retry"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
@@ -89,12 +92,18 @@ func getNodeLabelUpdate(node *v1.Node, instanceMetadata *cloudprovider.InstanceM
 	return labelsToUpdate
 }
 
-func updateNodeLabels(kubeClient clientset.Interface, recorder record.EventRecorder, node *v1.Node, instanceMetadata *cloudprovider.InstanceMetadata) bool {
+func updateNodeLabels(ctx context.Context, kubeClient clientset.Interface, recorder record.EventRecorder, node *v1.Node, instanceMetadata *cloudprovider.InstanceMetadata) bool {
+	providerIDUpdated, err := updateNodeProviderID(ctx, kubeClient, node, instanceMetadata.ProviderID)
+	if err != nil {
+		klog.ErrorS(err, "error updating providerID for the node", "node", klog.KRef("", node.Name))
+		return false
+	}
+
 	labelsToUpdate := getNodeLabelUpdate(node, instanceMetadata)
 
 	if len(labelsToUpdate) == 0 {
 		klog.V(5).Infof("Skipping label update for node %q since there are no changes", node.Name)
-		return false
+		return providerIDUpdated
 	}
 
 	if !cloudnodeutil.AddOrUpdateLabelsOnNode(kubeClient, labelsToUpdate, node) {
@@ -134,6 +143,42 @@ func updateNodeLabels(kubeClient clientset.Interface, recorder record.EventRecor
 
 	}
 	return true
+}
+
+// updateNodeProviderID repairs nodes that were initialized by the cloud-node
+// controller without persisting the providerID. An existing providerID is never
+// overwritten, as it may belong to another cloud provider.
+func updateNodeProviderID(ctx context.Context, kubeClient clientset.Interface, node *v1.Node, providerID string) (bool, error) {
+	if node.Spec.ProviderID != "" || providerID == "" {
+		return false, nil
+	}
+
+	updated := false
+	err := clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
+		currentNode, err := kubeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if currentNode.Spec.ProviderID != "" {
+			return nil
+		}
+
+		currentNode.Spec.ProviderID = providerID
+		if _, err = kubeClient.CoreV1().Nodes().Update(ctx, currentNode, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+
+		updated = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	if updated {
+		klog.InfoS("Set providerID on node from Xen Orchestra metadata", "node", klog.KRef("", node.Name), "providerID", providerID)
+	}
+
+	return updated, nil
 }
 
 func getCloudTaint(taints []v1.Taint) *v1.Taint {

--- a/pkg/controllers/nodelabelsync/helper_update_test.go
+++ b/pkg/controllers/nodelabelsync/helper_update_test.go
@@ -83,7 +83,7 @@ func TestUpdateNodeLabels_NoChanges(t *testing.T) {
 		},
 	}
 
-	changed := updateNodeLabels(client, recorder, testNode, meta)
+	changed := updateNodeLabels(ctx, client, recorder, testNode, meta)
 	assert.False(t, changed, "expected no changes")
 
 	// Node labels should remain unchanged
@@ -101,6 +101,56 @@ func TestUpdateNodeLabels_NoChanges(t *testing.T) {
 	assert.Len(t, evs, 0, "expected no events")
 }
 
+func TestUpdateNodeLabels_SetsMissingProviderID(t *testing.T) {
+	ctx := context.TODO()
+	client := k8sfake.NewClientset()
+	recorder := record.NewFakeRecorder(10)
+	node := testNode.DeepCopy()
+	node.Name = "node-missing-provider-id"
+
+	_, err := client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to seed fake node: %v", err)
+	}
+
+	const providerID = "xenorchestra://pool-id/vm-id"
+	changed := updateNodeLabels(ctx, client, recorder, node, &cloudprovider.InstanceMetadata{
+		ProviderID: providerID,
+	})
+	assert.True(t, changed, "expected the missing providerID to be set")
+
+	got, err := client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	assert.Equal(t, providerID, got.Spec.ProviderID)
+}
+
+func TestUpdateNodeLabels_DoesNotOverwriteProviderID(t *testing.T) {
+	ctx := context.TODO()
+	client := k8sfake.NewClientset()
+	recorder := record.NewFakeRecorder(10)
+	node := testNode.DeepCopy()
+	node.Name = "node-existing-provider-id"
+	node.Spec.ProviderID = "other://instance-id"
+
+	_, err := client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to seed fake node: %v", err)
+	}
+
+	changed := updateNodeLabels(ctx, client, recorder, node, &cloudprovider.InstanceMetadata{
+		ProviderID: "xenorchestra://pool-id/vm-id",
+	})
+	assert.False(t, changed, "expected the existing providerID to remain unchanged")
+
+	got, err := client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	assert.Equal(t, "other://instance-id", got.Spec.ProviderID)
+}
+
 func TestUpdateNodeLabels_ZoneChanged(t *testing.T) {
 	ctx := context.TODO()
 	client := k8sfake.NewClientset()
@@ -113,7 +163,7 @@ func TestUpdateNodeLabels_ZoneChanged(t *testing.T) {
 
 	meta := &cloudprovider.InstanceMetadata{Zone: "host-2"}
 
-	changed := updateNodeLabels(client, recorder, testNode, meta)
+	changed := updateNodeLabels(ctx, client, recorder, testNode, meta)
 	assert.True(t, changed, "expected changes due to zone update")
 
 	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})
@@ -146,7 +196,7 @@ func TestUpdateNodeLabels_RegionChanged(t *testing.T) {
 
 	meta := &cloudprovider.InstanceMetadata{Region: "pool-2"}
 
-	changed := updateNodeLabels(client, recorder, testNode, meta)
+	changed := updateNodeLabels(ctx, client, recorder, testNode, meta)
 	assert.True(t, changed, "expected changes due to region update")
 
 	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})
@@ -178,7 +228,7 @@ func TestUpdateNodeLabels_InstanceTypeChanged(t *testing.T) {
 
 	meta := &cloudprovider.InstanceMetadata{InstanceType: "2vCPU-4GB"}
 
-	changed := updateNodeLabels(client, recorder, testNode, meta)
+	changed := updateNodeLabels(ctx, client, recorder, testNode, meta)
 	assert.True(t, changed, "expected changes due to instance type update")
 
 	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})
@@ -216,7 +266,7 @@ func TestUpdateNodeLabels_APIFailure(t *testing.T) {
 
 	meta := &cloudprovider.InstanceMetadata{Zone: "host-2"}
 
-	changed := updateNodeLabels(client, recorder, testNode, meta)
+	changed := updateNodeLabels(ctx, client, recorder, testNode, meta)
 	assert.False(t, changed, "expected failure to return false")
 
 	got, err := client.CoreV1().Nodes().Get(ctx, testNode.Name, metav1.GetOptions{})

--- a/pkg/controllers/nodelabelsync/node_label_sync_controller.go
+++ b/pkg/controllers/nodelabelsync/node_label_sync_controller.go
@@ -175,7 +175,7 @@ func (c *Controller) UpdateNodeLabels(ctx context.Context) error {
 			klog.Errorf("Error getting instance metadata for node label sync: %v", err)
 			return
 		}
-		updateNodeLabels(c.kubeClient, c.recorder, node, instanceMetadata)
+		updateNodeLabels(ctx, c.kubeClient, c.recorder, node, instanceMetadata)
 	}
 
 	workqueue.ParallelizeUntil(ctx, int(c.workerCount), len(nodes), updateNodeFunc)


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Xen Orchestra CCM will first have to approve the PR.
-->
## Why? (reasoning)
When using CAPI, the providerID is not setup sometimes

## What? (description)

Make providerID updates more consistent

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [X] you included tests (if applicable)
- [X] you linted your code (`make lint`)
- [X] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
