### PR TITLE
chore: update release workflow and handle chart-only releases

### DIFF
--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -15,14 +15,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - name: Install chart-testing tools
-        id: lint
-        uses: helm/chart-testing-action@v2.8.0
-
-      - name: Run helm chart linter
-        run: ct --config hack/ct.yml lint
       - name: Run helm template
         run: make helm-unit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Validate release
         shell: bash
         run: |
-          if [[ ! "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[1-9][0-9]*)?$ ]]; then
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "Invalid release tag: $GITHUB_REF_NAME"
             exit 1
           fi
@@ -36,6 +36,12 @@ jobs:
           if [ "$app_version" != "$expected_app_version" ]; then
             echo "Chart appVersion ($app_version) must match the application version ($expected_app_version)"
             exit 1
+          fi
+
+          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[1-9][0-9]*$ ]]; then
+            echo "CHART_ONLY=true" >> "$GITHUB_ENV"
+          else
+            echo "CHART_ONLY=false" >> "$GITHUB_ENV"
           fi
 
           echo "APP_VERSION=$app_version" >> "$GITHUB_ENV"
@@ -59,6 +65,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
+        if: env.CHART_ONLY != 'true'
         timeout-minutes: 10
         run: make images
         env:
@@ -66,6 +73,7 @@ jobs:
           TAG: ${{ env.APP_VERSION }}
           VERSION: ${{ env.APP_VERSION }}
       - name: Sign image
+        if: env.CHART_ONLY != 'true'
         timeout-minutes: 4
         run: make images-cosign
         env:

--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,6 @@ unit: ## Unit Tests
 
 ############
 
-.PHONY: helm-lint
-helm-lint:
-	@ct --config hack/ct.yml lint --check-version-increment=false
-
 .PHONY: helm-unit
 helm-unit: ## Helm Unit Tests
 	@helm lint charts/xenorchestra-cloud-controller-manager

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,33 +1,84 @@
 # Release
 
-Each release publishes the application image and Helm chart from one Git tag:
+Each release is triggered by a Git tag and publishes the application image and/or the Helm chart from the tagged commit.
 
-```text
-vAPP_VERSION
-vAPP_VERSION-CHART_INCREMENT
-```
+## The three versions
 
-The first tag for an application version omits the `-0` suffix. The `-CHART_INCREMENT` suffix is only used when the chart changes without changing the application image. If the application image changes, bump `APP_VERSION` instead.
+| Element | Format | Where |
+|---------|--------|-------|
+| Application image | `vX.Y.Z` | Docker tag, value of `appVersion` |
+| Chart | `X.Y.Z` (no `v` prefix) | `version` in `Chart.yaml`, independent of the app |
+| Release tag | `vAPP[-N]` | Git tag that triggers the CI; `N` is the number of chart-only releases for that app version |
 
-For example, use `v1.2.3` for the first release of that application version, then `v1.2.3-1` if only the chart changes while reusing the `v1.2.3` image.
+The chart version is **decoupled** from the app version: it follows its own semver. The chart's `appVersion` is the version of the application deployed by default (`image.tag` is empty by default, so the deployment uses `appVersion` as the image tag; users can override with `--set image.tag=...`).
 
-The chart version remains independent. Before creating the tag:
+## Chart version bump
 
-1. Bump `version` and set `appVersion` to `vAPP_VERSION` in `Chart.yaml`.
-2. Generate the release files.
+The chart `version` reflects changes to the chart itself:
 
-```shell
-TAG=vAPP_VERSION make docs
-RELEASE_TAG=vAPP_VERSION make release-update
-```
+| Situation | Bump |
+|-----------|------|
+| App release, only `appVersion` changes | patch |
+| Chart fix (values, templates) | patch |
+| Backward-compatible chart feature (new value, new option) | minor |
+| Breaking chart change (renamed value, changed default) | major |
 
-For a chart-only release using the same application image, use `RELEASE_TAG=vAPP_VERSION-CHART_INCREMENT` instead. Start the chart increment at `1`.
+Rules:
 
-3. Merge the changes into `main`, then create and push the tag.
+- An app release always bumps the chart by a **patch**, even if the app itself is a minor or major release. The app version change is carried by `appVersion` and the image tag; if you want to control the app version, pin it with `image.tag`.
+- The `version` bump happens in the release commit (the one carrying the tag), not in every pull request. Several pull requests can accumulate chart changes; the last one before tagging applies the bump according to the table. If the bump is forgotten, the OCI registry rejects the duplicate chart version at release time.
 
-```shell
-git tag vAPP_VERSION
-git push origin vAPP_VERSION
-```
+## Case 1: App release
 
-The Git tag identifies the release. The application image and the chart's `appVersion` use `vAPP_VERSION`.
+The application code changes, with or without chart changes.
+
+1. In `Chart.yaml`, set `appVersion` to the new app version `vX.Y.Z`. Bump `version`: patch if the chart is otherwise unchanged, otherwise according to the table above.
+2. Generate the release files:
+
+   ```shell
+   TAG=vX.Y.Z make docs
+   RELEASE_TAG=vX.Y.Z make release-update
+   ```
+
+3. Merge into `main`, then create and push the tag:
+
+   ```shell
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+4. The CI builds and pushes the image `vX.Y.Z`, signs it, and publishes the chart.
+
+> Example: app is at `v1.1.1`, chart `version` is `1.2.0`. A bugfix app release `v1.1.2` with no chart change → `appVersion: v1.1.2`, `version: 1.2.1`, tag `v1.1.2`.
+>
+> Example: a new app release `v1.2.0` that also adds a new chart value → `appVersion: v1.2.0`, `version: 1.3.0` (feature = minor), tag `v1.2.0`.
+
+## Case 2: Chart-only release
+
+Only `charts/**` changes, the application is unchanged.
+
+1. In `Chart.yaml`, bump `version` according to the table above. Leave `appVersion` unchanged.
+2. Regenerate the chart documentation:
+
+   ```shell
+   make docs
+   ```
+
+3. Merge into `main`, then tag with `N`, the next unused increment for the current app version:
+
+   ```shell
+   git tag v<app>-N
+   git push origin v<app>-N
+   ```
+
+4. The CI publishes the chart only; the image is not rebuilt.
+
+Conditions:
+
+- The app image `v<app>` must already have been released.
+- The pull request must not contain application code changes.
+- If a chart change is pending when you prepare an app release, fold it into the app release (case 1) instead of tagging a chart-only release first.
+
+> Example (current state): app `v1.1.1` is already released, the chart `version` is `1.2.0` (a new feature, `rbac.create`, is pending). Tag `v1.1.1-1` publishes chart `1.2.0` without touching the image.
+>
+> Example: after the app release `v1.2.0` (case 1), a chart bugfix → bump `version`, tag `v1.2.0-1`.

--- a/hack/ct.yml
+++ b/hack/ct.yml
@@ -1,9 +1,0 @@
-helm-extra-args: --timeout 300s
-check-version-increment: false
-debug: true
-chart-dirs:
-  - charts
-validate-maintainers: false
-namespace: default
-release-label: test
-target-branch: main


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Xen Orchestra CCM will first have to approve the PR.
-->

## Why? (reasoning)

The release workflow was not explicit enough 

## What? (description)

- We now update chart version with latest app version
- App is not builded and pushed anymore when only the chart is updated
- Cases are now explicit and have examples

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
